### PR TITLE
Elm v0.19.0 support + minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-docs",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "keywords": [
     "documentation",
     "docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-docs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "keywords": [
     "documentation",
     "docs",


### PR DESCRIPTION
I've added support for Elm v0.19.0 and some minor fixes for markdown formatting and type docs when type constructor is not exposed in the module.